### PR TITLE
Add optional HTTP basic auth to mailman3 Nginx site

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -20,6 +20,16 @@ mailman3_http_user: www-data
 mailman3_nginx_remove_default: false
 mailman3_nginx_self_crt: "{{ not mailman3_install_certbot | bool }}"
 
+# nginx HTTP Basic authentication
+mailman3_nginx_http_access: false
+mailman3_nginx_http_satisfy: any
+mailman3_nginx_http_deny: []
+mailman3_nginx_http_allow: []
+mailman3_nginx_htpasswd: true
+mailman3_nginx_htpasswd_path: /etc/nginx/.htpasswd
+mailman3_nginx_htpasswd_users:
+  - { user: "mailman", pass: "change_mailman_pass" }
+
 ## nginx-main
 mailman3_nginx_main_template: false
 mailman3_nginx_main_ssl_protocols: [TLSv1.2, TLSv1.3]

--- a/tasks/nginx.yml
+++ b/tasks/nginx.yml
@@ -29,6 +29,23 @@
       - ssl_prefer_server_ciphers
     notify: restart nginx
 
+  - when: mailman3_nginx_http_access and mailman3_nginx_htpasswd
+    block:
+    - name: Install passlib for htaccess
+      apt:
+        name: python3-passlib
+
+    - name: Nginx | Create htpasswd
+      community.general.htpasswd:
+        path: '{{ mailman3_nginx_htpasswd_path }}'
+        name: '{{ item.user }}'
+        password: '{{ item.pass }}'
+        mode: 0640
+        owner: '{{ mailman3_http_user  }}'
+        group: '{{ mailman3_http_user  }}'
+      with_items: '{{ mailman3_nginx_htpasswd_users }}'
+      no_log: true # prevent plaintext password output
+
   - when: mailman3_nginx_template
     block:
     - name: create nginx site {{ mailman3_nginx_site }}
@@ -41,6 +58,7 @@
         backup: true
       with_items:
         - snippets/mailman3-site.conf
+        - snippets/mailman3-http-access.conf
         - sites-available/{{ mailman3_nginx_site }}
       notify: reload nginx
 

--- a/templates/nginx/sites-available/10-mailman3.conf.j2
+++ b/templates/nginx/sites-available/10-mailman3.conf.j2
@@ -18,8 +18,8 @@ server {
     server_name {{ '_' if mailman3_nginx_catch_all else mailman3_server_name }};
     return 301 https://$server_name$request_uri;
 
-    access_log  /var/log/nginx/mailman_access.log  combined;
-    error_log /var/log/nginx/mailman_error.log warn;
+    access_log /var/log/nginx/mailman_access.log combined;
+    error_log  /var/log/nginx/mailman_error.log warn;
 }
 {% if mailman3_nginx_ssl is defined and mailman3_nginx_ssl %}
 server {
@@ -37,9 +37,12 @@ server {
     client_max_body_size {{ mailman3_nginx_client_max_body_size }};
 
     include snippets/mailman3-site.conf;
+{% if mailman3_nginx_http_access %}
+    include snippets/mailman3-http-access.conf;
+{% endif %}
 
-    access_log  /var/log/nginx/mailman_access.log  combined;
-    error_log /var/log/nginx/mailman_error.log warn;
+    access_log /var/log/nginx/mailman_access.log combined;
+    error_log  /var/log/nginx/mailman_error.log warn;
 {% for file in mailman3_nginx_extra_includes | default([]) %}
     include {{ file }};
 {% endfor %}

--- a/templates/nginx/snippets/mailman3-http-access.conf.j2
+++ b/templates/nginx/snippets/mailman3-http-access.conf.j2
@@ -1,0 +1,15 @@
+{% if mailman3_nginx_http_allow %}
+satisfy {{ mailman3_nginx_http_satisfy }};
+{%   for address in mailman3_nginx_http_deny %}
+deny {{ address }};
+{%   endfor %}
+{%   for address in mailman3_nginx_http_allow %}
+allow {{ address }};
+{%   endfor %}
+deny all;
+
+{% endif %}
+{% if mailman3_nginx_htpasswd %}
+auth_basic           "{{ mailman3_nginx_htpasswd_msg | default('Restricted') }}";
+auth_basic_user_file {{ mailman3_nginx_htpasswd_path }};
+{% endif %}


### PR DESCRIPTION
HTTP basic auth for main Mailman3 site could be required as Mailman 3 shows all advertised lists on that site (in case we didn't set it up as custom site/domain in Mailman). The main site could be accessed via server name and have it protected behind HTTP basic auth. Sample configuration:

```yaml
mailman3_nginx_http_access: true
mailman3_nginx_http_allow:
  - 10.0.10.0/24
  - 1.2.3.4
mailman3_nginx_htpasswd_users:
  - { user: "mailman", pass: "my_dummy_p4SS30rd" }
```

results in the following `snippets/mailman3-http-access.conf`:

```nginx
satisfy any;
allow 10.0.10.0/24;
allow 1.2.3.4;
deny all;
 
auth_basic           "Restricted";
auth_basic_user_file /etc/nginx/.htpasswd;
```

which we could then also include in any other Mailman3 site:

```nginx
    include snippets/mailman3-http-access.conf;
```